### PR TITLE
Fix: Improve ghost AI in Pac-Man game

### DIFF
--- a/packman/index.html
+++ b/packman/index.html
@@ -246,37 +246,72 @@
                 this.y = y;
                 this.size = 18;
                 this.color = color;
-                this.direction = Math.floor(Math.random() * 4);
+                this.direction = Math.floor(Math.random() * 4); // 0=右, 1=下, 2=左, 3=上
                 this.speed = 1.5;
                 this.alive = true;
             }
-            
+
             update() {
                 if (!this.alive) return;
-                
-                // 簡単なAI：ランダム方向転換
-                if (Math.random() < 0.02) {
-                    this.direction = Math.floor(Math.random() * 4);
-                }
-                
+
                 let nextX = this.x;
                 let nextY = this.y;
+
+                if (this.direction === 0) nextX += this.speed;
+                if (this.direction === 1) nextY += this.speed;
+                if (this.direction === 2) nextX -= this.speed;
+                if (this.direction === 3) nextY -= this.speed;
+
+                // 壁に衝突したか、またはランダムなタイミングで方向転換
+                if (!this.canMoveTo(nextX, nextY) || Math.random() < 0.02) {
+                    this._chooseNewDirection();
+                }
+
+                nextX = this.x;
+                nextY = this.y;
                 
                 if (this.direction === 0) nextX += this.speed;
                 if (this.direction === 1) nextY += this.speed;
                 if (this.direction === 2) nextX -= this.speed;
                 if (this.direction === 3) nextY -= this.speed;
-                
+
                 if (this.canMoveTo(nextX, nextY)) {
                     this.x = nextX;
                     this.y = nextY;
-                } else {
-                    this.direction = Math.floor(Math.random() * 4);
                 }
-                
+
                 // 画面端でのワープ
                 if (this.x < -this.size/2) this.x = GAME_WIDTH - this.size/2;
                 if (this.x > GAME_WIDTH - this.size/2) this.x = -this.size/2;
+            }
+
+            _chooseNewDirection() {
+                const possibleDirections = [];
+                // 0=右, 1=下, 2=左, 3=上
+                for (let i = 0; i < 4; i++) {
+                    let testX = this.x, testY = this.y;
+                    if (i === 0) testX += this.speed;
+                    if (i === 1) testY += this.speed;
+                    if (i === 2) testX -= this.speed;
+                    if (i === 3) testY -= this.speed;
+
+                    if (this.canMoveTo(testX, testY)) {
+                        possibleDirections.push(i);
+                    }
+                }
+
+                // 来た道を戻らないようにする（行き止まりを除く）
+                if (possibleDirections.length > 1) {
+                    const oppositeDirection = (this.direction + 2) % 4;
+                    const index = possibleDirections.indexOf(oppositeDirection);
+                    if (index > -1) {
+                        possibleDirections.splice(index, 1);
+                    }
+                }
+
+                if (possibleDirections.length > 0) {
+                    this.direction = possibleDirections[Math.floor(Math.random() * possibleDirections.length)];
+                }
             }
             
             canMoveTo(x, y) {


### PR DESCRIPTION
The previous ghost AI in the Pac-Man game had a flaw where ghosts could get stuck against walls. This was because their movement logic allowed them to randomly choose a new direction without verifying if the path was obstructed.

This commit introduces a smarter movement algorithm for the ghosts. A new `_chooseNewDirection` method has been added to the `Ghost` class. This method identifies all valid moves from the ghost's current position and selects a new path, preventing the ghost from making immediate U-turns unless necessary. The `update` method has been refactored to use this new logic, ensuring ghosts can navigate the maze effectively and no longer get stuck.